### PR TITLE
Improve spin

### DIFF
--- a/src/oneway.jl
+++ b/src/oneway.jl
@@ -33,6 +33,8 @@ function waitif(f, cond::OneWayCondition, spin::Union{Nothing,Integer})
     if spin isa Integer
         for _ in Base.OneTo(spin)
             f() || return
+            ccall(:jl_cpu_pause, Cvoid, ())
+            GC.safepoint()
         end
     end
     cond.task = current_task()

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -20,8 +20,6 @@ macro _assert(args...)
     end |> esc
 end
 
-pause() = ccall(:jl_cpu_pause, Cvoid, ())
-
 function ceillog2(n::Integer)
     n > 0 || throw(DomainError(n))
     i = trailing_zeros(n)


### PR DESCRIPTION
We need to include `GC.safepoint()` just in case other tasks need to
allocate.  It also seems that this improves the performance of the
benchmark `suite["uniform_loops"]["dissemination"]["spin"]["spawn"]`.

Some benchmarks: https://gist.github.com/1ff032e31a94a4acb47d58d0fe2d6757